### PR TITLE
Add README files for each Flask project and root portfolio overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,60 @@
+# Flask Projects Portfolio
+
+A curated collection of Flask applications that showcase practical backend and full-stack web development skills across authentication, APIs, async tasks, real-time systems, and utility tools.
+
+## 👋 About This Repository
+This repository contains multiple independent Flask projects built while learning and applying different architecture patterns and ecosystem extensions. It is organized as a hands-on portfolio demonstrating progression from fundamentals to production-style integrations.
+
+## 🧩 Featured Projects
+
+### 1) Task & CRUD Applications
+- **`coursera_flask-tasks-app`** — Task management app with forms, routes, and model-driven workflows.
+- **`packt_learning-flask`** — Core Flask patterns using templates/static assets.
+- **`packt_flask-full-stack`** — Structured Flask package with models/forms/routes split.
+
+### 2) Authentication & Authorization
+- **`flask-login`** — Session-based login fundamentals.
+- **`flask-login-roles`** — Role-based access control patterns.
+- **`packt_ultimate_flask`** chapters on Flask-Login, Flask-User, and Flask-Security.
+
+### 3) APIs, Integrations, and Services
+- **`gsheetapi`** — Google Sheets API integration workflow.
+- **`gmail-auth`** — Gmail auth/integration sample.
+- **`flask-serve`** — Minimal service-style routing and template serving.
+
+### 4) Async & Background Workflows
+- **`flask-celery`** and **`flask-celery-template`** — Celery task queue integration with Flask.
+
+### 5) Real-Time & Socket Applications
+- **`flask-sockets`** — WebSocket-driven interaction patterns.
+
+### 6) Utility Applications
+- **`im2pdf`** — Image-to-PDF conversion utility app.
+
+## 🛠️ Technical Skills Demonstrated
+- Flask application factory and modular project layouts
+- Template rendering with Jinja2
+- Form handling and validation
+- Authentication and authorization flows
+- ORM and relational data modeling
+- Background task processing with Celery
+- Realtime communication (SocketIO/WebSockets)
+- Third-party API integration (Google services)
+
+## 🚀 Quick Start (Generic)
+```bash
+# from repository root
+python -m venv .venv
+source .venv/bin/activate
+pip install flask
+
+# run a specific project
+cd <project-folder>
+python app.py  # or python main.py depending on project
+```
+
+## 📁 Repository Structure
+Each top-level folder is a standalone project with its own code and (where applicable) requirements.
+
+## 📌 Purpose
+This monorepo serves as a professional showcase of Flask development capabilities, experimentation, and iterative learning across multiple real-world app patterns.

--- a/coursera_flask-tasks-app/README.md
+++ b/coursera_flask-tasks-app/README.md
@@ -1,0 +1,27 @@
+# Coursera Flask Tasks App
+
+A simple task management web app built with Flask as part of coursework exercises.
+
+## Features
+- Create and manage tasks
+- Form handling with Flask-WTF
+- Server-rendered templates
+- SQLite-backed persistence (via the app configuration)
+
+## Project Structure
+- `app.py` — application entry point
+- `routes.py` — route handlers
+- `models.py` — data models
+- `forms.py` — form definitions
+- `templates/` — HTML templates
+
+## Getting Started
+```bash
+cd coursera_flask-tasks-app
+python -m venv .venv
+source .venv/bin/activate
+pip install flask flask-wtf
+python app.py
+```
+
+Then open `http://127.0.0.1:5000` in your browser.

--- a/flask-login-roles/README.md
+++ b/flask-login-roles/README.md
@@ -1,0 +1,21 @@
+# Flask Login Roles
+
+A Flask authentication and authorization sample project demonstrating role-based access control.
+
+## Highlights
+- User authentication flow
+- Role-aware access patterns
+- Class-based and functional app patterns (`app_class.py`, `app.py`)
+
+## Files
+- `app.py` — main app flow
+- `app_class.py` — class-oriented variant
+
+## Run
+```bash
+cd flask-login-roles
+python -m venv .venv
+source .venv/bin/activate
+pip install flask flask-login
+python app.py
+```

--- a/flask-login/README.md
+++ b/flask-login/README.md
@@ -1,0 +1,17 @@
+# Flask Login Example
+
+A minimal Flask project focused on implementing user login sessions.
+
+## Features
+- Login/logout flow
+- Session-based authentication
+- Basic protected route examples
+
+## Run
+```bash
+cd flask-login
+python -m venv .venv
+source .venv/bin/activate
+pip install flask flask-login
+python app.py
+```

--- a/flask-serve/README.md
+++ b/flask-serve/README.md
@@ -1,0 +1,17 @@
+# Flask Serve
+
+A lightweight Flask serving example for rendering templates and basic route handling.
+
+## Structure
+- `app.py` — runnable entry point
+- `__init__.py` — package setup
+- `templates/` — frontend templates
+
+## Run
+```bash
+cd flask-serve
+python -m venv .venv
+source .venv/bin/activate
+pip install flask
+python app.py
+```

--- a/gsheetapi/README.md
+++ b/gsheetapi/README.md
@@ -1,0 +1,19 @@
+# GSheet API Flask App
+
+A Flask project for integrating with Google Sheets APIs.
+
+## What it Demonstrates
+- Flask route handling
+- API integration workflow
+- Dependency-driven setup via `requirements.txt`
+
+## Setup
+```bash
+cd gsheetapi
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+python app.py
+```
+
+> Note: You may need to configure Google API credentials before endpoints can be used.

--- a/im2pdf/README.md
+++ b/im2pdf/README.md
@@ -1,0 +1,17 @@
+# Image to PDF (Flask)
+
+A Flask utility app that converts uploaded images into PDF output.
+
+## Features
+- Image upload handling
+- Server-side conversion logic
+- Simple web interface
+
+## Run
+```bash
+cd im2pdf
+python -m venv .venv
+source .venv/bin/activate
+pip install flask
+python app.py
+```

--- a/packt_flask-full-stack/README.md
+++ b/packt_flask-full-stack/README.md
@@ -1,0 +1,21 @@
+# Packt Flask Full Stack
+
+A full-stack Flask learning project with forms, models, and route organization.
+
+## Components
+- `main.py` — launch point
+- `config.py` — configuration values
+- `application/` — package containing:
+  - `models.py`
+  - `forms.py`
+  - `routes.py`
+  - additional domain modules
+
+## Setup
+```bash
+cd packt_flask-full-stack
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+python main.py
+```

--- a/packt_ultimate_flask/README.md
+++ b/packt_ultimate_flask/README.md
@@ -1,0 +1,25 @@
+# Packt Ultimate Flask
+
+A multi-module Flask learning workspace containing chapter-based applications from beginner to advanced topics.
+
+## Included Topics
+- Flask fundamentals (`00_starter`, `00_flaskr-tutorial`)
+- Forms, templates, and ORM
+- Authentication and user systems
+- Migrations, uploads, i18n, and admin
+- REST APIs, sockets, and full app builds (store/forum/twitter clone)
+
+## Folder Naming
+Many folders are chapter snapshots, with:
+- `- O` meaning completed/reference implementation
+- `- X` meaning alternative/in-progress/experimental snapshot
+
+## How to Explore
+Open any chapter directory and run the app locally with its own dependencies:
+```bash
+cd "packt_ultimate_flask/<chapter-folder>"
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+python app.py
+```


### PR DESCRIPTION
### Motivation
- Provide a consistent entry point and per-project documentation to improve discoverability and onboarding for each top-level Flask project.
- Present the repository as a professional portfolio that highlights project categories and demonstrated Flask skills.

### Description
- Added a new root `README.md` that provides a portfolio overview, featured projects, technical skills, and a generic quick-start guide.
- Added project-level `README.md` files for `coursera_flask-tasks-app`, `flask-login-roles`, `flask-login`, `flask-serve`, `gsheetapi`, `im2pdf`, `packt_flask-full-stack`, and `packt_ultimate_flask` with short descriptions and run/setup instructions.
- This change is documentation-only and does not modify runtime code or application behavior.

### Testing
- Verified every top-level project now contains a `README.md` using `for d in */; do ...` presence checks, which reported the new files.
- Inspected the generated README contents by printing files with `nl -ba <file>` to confirm readable structure and instructions.
- Confirmed the repository status reflects the added README files using `git status --short`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af1aa3e02c832c89b7ced6d4bc58d8)